### PR TITLE
sqlalchemy-jsonfield 1.0.2 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,7 @@ requirements:
 # Lower bound for setuptools not required but recommended by upstream
     - setuptools >=61.0.0
     - setuptools_scm >=6.2
+    - toml
     - wheel
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,12 +41,6 @@ test:
   commands: 
     - pip check
     - pytest -vv functional_test/
-  downstreams:
-    - airflow 1.10.10
-    - airflow 1.10.12
-    - airflow 1.10.7
-    - airflow 2.3.3  # [py>=311]
-    - airflow 2.4.3  # [py>=311]
 
 about:
   home: https://github.com/penguinolog/sqlalchemy_jsonfield

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,6 +41,12 @@ test:
   commands: 
     - pip check
     - pytest -vv functional_test/
+  downstreams:
+    - airflow 1.10.10
+    - airflow 1.10.12
+    - airflow 1.10.7
+    - airflow 2.3.3  # [py>=311]
+    - airflow 2.4.3  # [py>=311]
 
 about:
   home: https://github.com/penguinolog/sqlalchemy_jsonfield

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,12 +1,12 @@
 {% set name = "SQLAlchemy-JSONField" %}
-{% set version = "1.0.1.post0" %}
+{% set version = "1.0.2" %}
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 72a5e714fe0493d2660abd7484a9fd9f492f493a0856288dd22a5decb29f5dc4
+  sha256: dab3abc9d75a1640e7f3d4875564a4199f665d27863da8d5a089e4eaca5e67f2
 
 build:
   number: 0
@@ -17,8 +17,9 @@ requirements:
   host:
     - python
     - pip
-    - setuptools
-    - setuptools_scm
+# Lower bound for setuptools not required but recommended by upstream
+    - setuptools >=61.0.0
+    - setuptools_scm >=6.2
     - wheel
   run:
     - python
@@ -36,10 +37,10 @@ test:
     - pytest-asyncio
     - psycopg2
     - postgresql  # [win]
-    - pymysql  # [not s390x]
+    - pymysql
   commands: 
     - pip check
-    - pytest -vv functional_test/  # [not s390x]
+    - pytest -vv functional_test/
 
 about:
   home: https://github.com/penguinolog/sqlalchemy_jsonfield


### PR DESCRIPTION
sqlalchemy-jsonfield 1.0.2 

**Destination channel:** Main

### Links

- [PKG-8558]
- dev_url:        https://github.com/penguinolog/sqlalchemy_jsonfield/tree/1.0.2
- conda_forge:    https://github.com/conda-forge/sqlalchemy-jsonfield-feedstock
- pypi:           https://pypi.org/project/sqlalchemy-jsonfield/1.0.2
- pypi inspector: https://inspector.pypi.io/project/sqlalchemy-jsonfield/1.0.2

### Explanation of changes:

- new version number


[PKG-8558]: https://anaconda.atlassian.net/browse/PKG-8558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ